### PR TITLE
Catch error if no albumart found.

### DIFF
--- a/lib/media_metadata_retriever.dart
+++ b/lib/media_metadata_retriever.dart
@@ -80,7 +80,12 @@ class MediaMetadataRetriever {
       await _methodChannel.invokeMethod('setFilePath', {
         'filePath': mediaFile.path,
       });
-      this.albumArt = await _methodChannel.invokeMethod('getAlbumArt');
+      try{
+        this.albumArt = await _methodChannel.invokeMethod('getAlbumArt');
+        }
+      catch(e){
+        this.albumArt = null;
+      }
     } else {
       throw 'ERROR: Media file does not exist.';
     }


### PR DESCRIPTION
Fix the bug, load file failed when no album art included in audio file.