### PR TITLE
Feature/add ioexception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0+2
+
+- Add IOException for `retriever.release()` because build error in ANDROID SDK 33.
+
 ## 1.0.0+1
 
 - Update `build:gradle` version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0+1
+
+- Update `build:gradle` version.
+- Change android dependencies set `android-retrofuture`. 
+
 ## 1.0.0
 
 - Now supporting all platforms Windows, Linux, macOS, Android, iOS & Web.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.4'
     }
 }
 
@@ -31,6 +31,6 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        compile 'net.sourceforge.streamsupport:android-retrofuture:1.7.2'
+        api 'net.sourceforge.streamsupport:android-retrofuture:1.7.2'
     }
 }

--- a/android/src/main/java/com/alexmercerind/flutter_media_metadata/FlutterMediaMetadataPlugin.java
+++ b/android/src/main/java/com/alexmercerind/flutter_media_metadata/FlutterMediaMetadataPlugin.java
@@ -3,6 +3,7 @@ package com.alexmercerind.flutter_media_metadata;
 import java.util.HashMap;
 import java.lang.Runnable;
 import java9.util.concurrent.CompletableFuture;
+import java.io.IOException;
 
 import android.os.Build;
 import android.os.Handler;
@@ -39,7 +40,11 @@ public class FlutterMediaMetadataPlugin implements FlutterPlugin, MethodCallHand
           final HashMap<String, Object> response = new HashMap<String, Object>();
           response.put("metadata", retriever.getMetadata());
           response.put("albumArt", retriever.getAlbumArt());
-          retriever.release();
+          try {
+            retriever.release();
+          } catch (IOException e) {
+            e.printStackTrace();
+          }
           new Handler(Looper.getMainLooper())
               .post(new Runnable() {
                 @Override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_media_metadata
 description: A Flutter plugin to read metadata of media files.
-version: 1.0.0+1
+version: 1.0.0+2
 homepage: https://github.com/alexmercerind/flutter_media_metadata
 repository: https://github.com/alexmercerind/flutter_media_metadata
 documentation: https://github.com/alexmercerind/flutter_media_metadata/blob/master/README.md

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_media_metadata
 description: A Flutter plugin to read metadata of media files.
-version: 1.0.0
+version: 1.0.0+1
 homepage: https://github.com/alexmercerind/flutter_media_metadata
 repository: https://github.com/alexmercerind/flutter_media_metadata
 documentation: https://github.com/alexmercerind/flutter_media_metadata/blob/master/README.md


### PR DESCRIPTION
Add IOException for `retriever.release()` because build error in ANDROID SDK 33.